### PR TITLE
feat: Support non-string parameter

### DIFF
--- a/color.go
+++ b/color.go
@@ -1,5 +1,7 @@
 package color
 
+import "fmt"
+
 var (
 	Reset = "\033[0m"
 
@@ -39,12 +41,26 @@ var (
 	WhiteBackground  = "\033[107m"
 )
 
+// Colorize wraps a given message in a given color.
+//
+// Example:
+//
+//	println(color.Colorize(color.Red, "This is red"))
+func Colorize(color string, s any) string {
+	switch s.(type) {
+	case string:
+		return color + s.(string) + Reset
+	default:
+		return color + fmt.Sprint(s) + Reset
+	}
+}
+
 // Ize is an alias for the Colorize function
 //
 // Example:
 //
 //	println(color.Ize(color.Red, "This is red"))
-func Ize(color, s string) string {
+func Ize(color string, s any) string {
 	return Colorize(color, s)
 }
 
@@ -53,17 +69,8 @@ func Ize(color, s string) string {
 // Example:
 //
 //	println(color.With(color.Red, "This is red"))
-func With(color, s string) string {
+func With(color string, s any) string {
 	return Colorize(color, s)
-}
-
-// Colorize wraps a given message in a given color.
-//
-// Example:
-//
-//	println(color.Colorize(color.Red, "This is red"))
-func Colorize(color, s string) string {
-	return color + s + Reset
 }
 
 // InBold wraps the given string s in Bold
@@ -71,7 +78,7 @@ func Colorize(color, s string) string {
 // Example:
 //
 //	println(color.InBold("This is bold"))
-func InBold(s string) string {
+func InBold(s any) string {
 	return Colorize(Bold, s)
 }
 
@@ -80,7 +87,7 @@ func InBold(s string) string {
 // Example:
 //
 //	println(color.InUnderline("This is underlined"))
-func InUnderline(s string) string {
+func InUnderline(s any) string {
 	return Colorize(Underline, s)
 }
 
@@ -89,7 +96,7 @@ func InUnderline(s string) string {
 // Example:
 //
 //	println(color.InBlack("This is black"))
-func InBlack(s string) string {
+func InBlack(s any) string {
 	return Colorize(Black, s)
 }
 
@@ -98,7 +105,7 @@ func InBlack(s string) string {
 // Example:
 //
 //	println(color.InRed("This is red"))
-func InRed(s string) string {
+func InRed(s any) string {
 	return Colorize(Red, s)
 }
 
@@ -107,7 +114,7 @@ func InRed(s string) string {
 // Example:
 //
 //	println(color.InGreen("This is green"))
-func InGreen(s string) string {
+func InGreen(s any) string {
 	return Colorize(Green, s)
 }
 
@@ -116,7 +123,7 @@ func InGreen(s string) string {
 // Example:
 //
 //	println(color.InYellow("This is yellow"))
-func InYellow(s string) string {
+func InYellow(s any) string {
 	return Colorize(Yellow, s)
 }
 
@@ -125,7 +132,7 @@ func InYellow(s string) string {
 // Example:
 //
 //	println(color.InBlue("This is blue"))
-func InBlue(s string) string {
+func InBlue(s any) string {
 	return Colorize(Blue, s)
 }
 
@@ -134,7 +141,7 @@ func InBlue(s string) string {
 // Example:
 //
 //	println(color.InPurple("This is purple"))
-func InPurple(s string) string {
+func InPurple(s any) string {
 	return Colorize(Purple, s)
 }
 
@@ -143,7 +150,7 @@ func InPurple(s string) string {
 // Example:
 //
 //	println(color.InCyan("This is cyan"))
-func InCyan(s string) string {
+func InCyan(s any) string {
 	return Colorize(Cyan, s)
 }
 
@@ -152,7 +159,7 @@ func InCyan(s string) string {
 // Example:
 //
 //	println(color.InGray("This is gray"))
-func InGray(s string) string {
+func InGray(s any) string {
 	return Colorize(Gray, s)
 }
 
@@ -161,7 +168,7 @@ func InGray(s string) string {
 // Example:
 //
 //	println(color.InWhite("This is white"))
-func InWhite(s string) string {
+func InWhite(s any) string {
 	return Colorize(White, s)
 }
 
@@ -170,7 +177,7 @@ func InWhite(s string) string {
 // Example:
 //
 //	println(color.OverBlack("This is over black"))
-func OverBlack(s string) string {
+func OverBlack(s any) string {
 	return Colorize(BlackBackground, s)
 }
 
@@ -179,7 +186,7 @@ func OverBlack(s string) string {
 // Example:
 //
 //	println(color.OverRed("This is over red"))
-func OverRed(s string) string {
+func OverRed(s any) string {
 	return Colorize(RedBackground, s)
 }
 
@@ -188,7 +195,7 @@ func OverRed(s string) string {
 // Example:
 //
 //	println(color.OverGreen("This is over green"))
-func OverGreen(s string) string {
+func OverGreen(s any) string {
 	return Colorize(GreenBackground, s)
 }
 
@@ -197,7 +204,7 @@ func OverGreen(s string) string {
 // Example:
 //
 //	println(color.OverYellow("This is over yellow"))
-func OverYellow(s string) string {
+func OverYellow(s any) string {
 	return Colorize(YellowBackground, s)
 }
 
@@ -206,7 +213,7 @@ func OverYellow(s string) string {
 // Example:
 //
 //	println(color.OverBlue("This is over blue"))
-func OverBlue(s string) string {
+func OverBlue(s any) string {
 	return Colorize(BlueBackground, s)
 }
 
@@ -215,7 +222,7 @@ func OverBlue(s string) string {
 // Example:
 //
 //	println(color.OverPurple("This is over purple"))
-func OverPurple(s string) string {
+func OverPurple(s any) string {
 	return Colorize(PurpleBackground, s)
 }
 
@@ -224,7 +231,7 @@ func OverPurple(s string) string {
 // Example:
 //
 //	println(color.OverCyan("This is over cyan"))
-func OverCyan(s string) string {
+func OverCyan(s any) string {
 	return Colorize(CyanBackground, s)
 }
 
@@ -233,7 +240,7 @@ func OverCyan(s string) string {
 // Example:
 //
 //	println(color.OverGray("This is over gray"))
-func OverGray(s string) string {
+func OverGray(s any) string {
 	return Colorize(GrayBackground, s)
 }
 
@@ -242,88 +249,88 @@ func OverGray(s string) string {
 // Example:
 //
 //	println(color.OverWhite("This is over white"))
-func OverWhite(s string) string {
+func OverWhite(s any) string {
 	return Colorize(WhiteBackground, s)
 }
 
-func InBlackOverBlack(s string) string   { return Colorize(Black+BlackBackground, s) }
-func InBlackOverRed(s string) string     { return Colorize(Black+RedBackground, s) }
-func InBlackOverGreen(s string) string   { return Colorize(Black+GreenBackground, s) }
-func InBlackOverYellow(s string) string  { return Colorize(Black+YellowBackground, s) }
-func InBlackOverBlue(s string) string    { return Colorize(Black+BlueBackground, s) }
-func InBlackOverPurple(s string) string  { return Colorize(Black+PurpleBackground, s) }
-func InBlackOverCyan(s string) string    { return Colorize(Black+CyanBackground, s) }
-func InBlackOverGray(s string) string    { return Colorize(Black+GrayBackground, s) }
-func InBlackOverWhite(s string) string   { return Colorize(Black+WhiteBackground, s) }
-func InRedOverBlack(s string) string     { return Colorize(Red+BlackBackground, s) }
-func InRedOverRed(s string) string       { return Colorize(Red+RedBackground, s) }
-func InRedOverGreen(s string) string     { return Colorize(Red+GreenBackground, s) }
-func InRedOverYellow(s string) string    { return Colorize(Red+YellowBackground, s) }
-func InRedOverBlue(s string) string      { return Colorize(Red+BlueBackground, s) }
-func InRedOverPurple(s string) string    { return Colorize(Red+PurpleBackground, s) }
-func InRedOverCyan(s string) string      { return Colorize(Red+CyanBackground, s) }
-func InRedOverGray(s string) string      { return Colorize(Red+GrayBackground, s) }
-func InRedOverWhite(s string) string     { return Colorize(Red+WhiteBackground, s) }
-func InGreenOverBlack(s string) string   { return Colorize(Green+BlackBackground, s) }
-func InGreenOverRed(s string) string     { return Colorize(Green+RedBackground, s) }
-func InGreenOverGreen(s string) string   { return Colorize(Green+GreenBackground, s) }
-func InGreenOverYellow(s string) string  { return Colorize(Green+YellowBackground, s) }
-func InGreenOverBlue(s string) string    { return Colorize(Green+BlueBackground, s) }
-func InGreenOverPurple(s string) string  { return Colorize(Green+PurpleBackground, s) }
-func InGreenOverCyan(s string) string    { return Colorize(Green+CyanBackground, s) }
-func InGreenOverGray(s string) string    { return Colorize(Green+GrayBackground, s) }
-func InGreenOverWhite(s string) string   { return Colorize(Green+WhiteBackground, s) }
-func InYellowOverBlack(s string) string  { return Colorize(Yellow+BlackBackground, s) }
-func InYellowOverRed(s string) string    { return Colorize(Yellow+RedBackground, s) }
-func InYellowOverGreen(s string) string  { return Colorize(Yellow+GreenBackground, s) }
-func InYellowOverYellow(s string) string { return Colorize(Yellow+YellowBackground, s) }
-func InYellowOverBlue(s string) string   { return Colorize(Yellow+BlueBackground, s) }
-func InYellowOverPurple(s string) string { return Colorize(Yellow+PurpleBackground, s) }
-func InYellowOverCyan(s string) string   { return Colorize(Yellow+CyanBackground, s) }
-func InYellowOverGray(s string) string   { return Colorize(Yellow+GrayBackground, s) }
-func InYellowOverWhite(s string) string  { return Colorize(Yellow+WhiteBackground, s) }
-func InBlueOverBlack(s string) string    { return Colorize(Blue+BlackBackground, s) }
-func InBlueOverRed(s string) string      { return Colorize(Blue+RedBackground, s) }
-func InBlueOverGreen(s string) string    { return Colorize(Blue+GreenBackground, s) }
-func InBlueOverYellow(s string) string   { return Colorize(Blue+YellowBackground, s) }
-func InBlueOverBlue(s string) string     { return Colorize(Blue+BlueBackground, s) }
-func InBlueOverPurple(s string) string   { return Colorize(Blue+PurpleBackground, s) }
-func InBlueOverCyan(s string) string     { return Colorize(Blue+CyanBackground, s) }
-func InBlueOverGray(s string) string     { return Colorize(Blue+GrayBackground, s) }
-func InBlueOverWhite(s string) string    { return Colorize(Blue+WhiteBackground, s) }
-func InPurpleOverBlack(s string) string  { return Colorize(Purple+BlackBackground, s) }
-func InPurpleOverRed(s string) string    { return Colorize(Purple+RedBackground, s) }
-func InPurpleOverGreen(s string) string  { return Colorize(Purple+GreenBackground, s) }
-func InPurpleOverYellow(s string) string { return Colorize(Purple+YellowBackground, s) }
-func InPurpleOverBlue(s string) string   { return Colorize(Purple+BlueBackground, s) }
-func InPurpleOverPurple(s string) string { return Colorize(Purple+PurpleBackground, s) }
-func InPurpleOverCyan(s string) string   { return Colorize(Purple+CyanBackground, s) }
-func InPurpleOverGray(s string) string   { return Colorize(Purple+GrayBackground, s) }
-func InPurpleOverWhite(s string) string  { return Colorize(Purple+WhiteBackground, s) }
-func InCyanOverBlack(s string) string    { return Colorize(Cyan+BlackBackground, s) }
-func InCyanOverRed(s string) string      { return Colorize(Cyan+RedBackground, s) }
-func InCyanOverGreen(s string) string    { return Colorize(Cyan+GreenBackground, s) }
-func InCyanOverYellow(s string) string   { return Colorize(Cyan+YellowBackground, s) }
-func InCyanOverBlue(s string) string     { return Colorize(Cyan+BlueBackground, s) }
-func InCyanOverPurple(s string) string   { return Colorize(Cyan+PurpleBackground, s) }
-func InCyanOverCyan(s string) string     { return Colorize(Cyan+CyanBackground, s) }
-func InCyanOverGray(s string) string     { return Colorize(Cyan+GrayBackground, s) }
-func InCyanOverWhite(s string) string    { return Colorize(Cyan+WhiteBackground, s) }
-func InGrayOverBlack(s string) string    { return Colorize(Gray+BlackBackground, s) }
-func InGrayOverRed(s string) string      { return Colorize(Gray+RedBackground, s) }
-func InGrayOverGreen(s string) string    { return Colorize(Gray+GreenBackground, s) }
-func InGrayOverYellow(s string) string   { return Colorize(Gray+YellowBackground, s) }
-func InGrayOverBlue(s string) string     { return Colorize(Gray+BlueBackground, s) }
-func InGrayOverPurple(s string) string   { return Colorize(Gray+PurpleBackground, s) }
-func InGrayOverCyan(s string) string     { return Colorize(Gray+CyanBackground, s) }
-func InGrayOverGray(s string) string     { return Colorize(Gray+GrayBackground, s) }
-func InGrayOverWhite(s string) string    { return Colorize(Gray+WhiteBackground, s) }
-func InWhiteOverBlack(s string) string   { return Colorize(White+BlackBackground, s) }
-func InWhiteOverRed(s string) string     { return Colorize(White+RedBackground, s) }
-func InWhiteOverGreen(s string) string   { return Colorize(White+GreenBackground, s) }
-func InWhiteOverYellow(s string) string  { return Colorize(White+YellowBackground, s) }
-func InWhiteOverBlue(s string) string    { return Colorize(White+BlueBackground, s) }
-func InWhiteOverPurple(s string) string  { return Colorize(White+PurpleBackground, s) }
-func InWhiteOverCyan(s string) string    { return Colorize(White+CyanBackground, s) }
-func InWhiteOverGray(s string) string    { return Colorize(White+GrayBackground, s) }
-func InWhiteOverWhite(s string) string   { return Colorize(White+WhiteBackground, s) }
+func InBlackOverBlack(s any) string   { return Colorize(Black+BlackBackground, s) }
+func InBlackOverRed(s any) string     { return Colorize(Black+RedBackground, s) }
+func InBlackOverGreen(s any) string   { return Colorize(Black+GreenBackground, s) }
+func InBlackOverYellow(s any) string  { return Colorize(Black+YellowBackground, s) }
+func InBlackOverBlue(s any) string    { return Colorize(Black+BlueBackground, s) }
+func InBlackOverPurple(s any) string  { return Colorize(Black+PurpleBackground, s) }
+func InBlackOverCyan(s any) string    { return Colorize(Black+CyanBackground, s) }
+func InBlackOverGray(s any) string    { return Colorize(Black+GrayBackground, s) }
+func InBlackOverWhite(s any) string   { return Colorize(Black+WhiteBackground, s) }
+func InRedOverBlack(s any) string     { return Colorize(Red+BlackBackground, s) }
+func InRedOverRed(s any) string       { return Colorize(Red+RedBackground, s) }
+func InRedOverGreen(s any) string     { return Colorize(Red+GreenBackground, s) }
+func InRedOverYellow(s any) string    { return Colorize(Red+YellowBackground, s) }
+func InRedOverBlue(s any) string      { return Colorize(Red+BlueBackground, s) }
+func InRedOverPurple(s any) string    { return Colorize(Red+PurpleBackground, s) }
+func InRedOverCyan(s any) string      { return Colorize(Red+CyanBackground, s) }
+func InRedOverGray(s any) string      { return Colorize(Red+GrayBackground, s) }
+func InRedOverWhite(s any) string     { return Colorize(Red+WhiteBackground, s) }
+func InGreenOverBlack(s any) string   { return Colorize(Green+BlackBackground, s) }
+func InGreenOverRed(s any) string     { return Colorize(Green+RedBackground, s) }
+func InGreenOverGreen(s any) string   { return Colorize(Green+GreenBackground, s) }
+func InGreenOverYellow(s any) string  { return Colorize(Green+YellowBackground, s) }
+func InGreenOverBlue(s any) string    { return Colorize(Green+BlueBackground, s) }
+func InGreenOverPurple(s any) string  { return Colorize(Green+PurpleBackground, s) }
+func InGreenOverCyan(s any) string    { return Colorize(Green+CyanBackground, s) }
+func InGreenOverGray(s any) string    { return Colorize(Green+GrayBackground, s) }
+func InGreenOverWhite(s any) string   { return Colorize(Green+WhiteBackground, s) }
+func InYellowOverBlack(s any) string  { return Colorize(Yellow+BlackBackground, s) }
+func InYellowOverRed(s any) string    { return Colorize(Yellow+RedBackground, s) }
+func InYellowOverGreen(s any) string  { return Colorize(Yellow+GreenBackground, s) }
+func InYellowOverYellow(s any) string { return Colorize(Yellow+YellowBackground, s) }
+func InYellowOverBlue(s any) string   { return Colorize(Yellow+BlueBackground, s) }
+func InYellowOverPurple(s any) string { return Colorize(Yellow+PurpleBackground, s) }
+func InYellowOverCyan(s any) string   { return Colorize(Yellow+CyanBackground, s) }
+func InYellowOverGray(s any) string   { return Colorize(Yellow+GrayBackground, s) }
+func InYellowOverWhite(s any) string  { return Colorize(Yellow+WhiteBackground, s) }
+func InBlueOverBlack(s any) string    { return Colorize(Blue+BlackBackground, s) }
+func InBlueOverRed(s any) string      { return Colorize(Blue+RedBackground, s) }
+func InBlueOverGreen(s any) string    { return Colorize(Blue+GreenBackground, s) }
+func InBlueOverYellow(s any) string   { return Colorize(Blue+YellowBackground, s) }
+func InBlueOverBlue(s any) string     { return Colorize(Blue+BlueBackground, s) }
+func InBlueOverPurple(s any) string   { return Colorize(Blue+PurpleBackground, s) }
+func InBlueOverCyan(s any) string     { return Colorize(Blue+CyanBackground, s) }
+func InBlueOverGray(s any) string     { return Colorize(Blue+GrayBackground, s) }
+func InBlueOverWhite(s any) string    { return Colorize(Blue+WhiteBackground, s) }
+func InPurpleOverBlack(s any) string  { return Colorize(Purple+BlackBackground, s) }
+func InPurpleOverRed(s any) string    { return Colorize(Purple+RedBackground, s) }
+func InPurpleOverGreen(s any) string  { return Colorize(Purple+GreenBackground, s) }
+func InPurpleOverYellow(s any) string { return Colorize(Purple+YellowBackground, s) }
+func InPurpleOverBlue(s any) string   { return Colorize(Purple+BlueBackground, s) }
+func InPurpleOverPurple(s any) string { return Colorize(Purple+PurpleBackground, s) }
+func InPurpleOverCyan(s any) string   { return Colorize(Purple+CyanBackground, s) }
+func InPurpleOverGray(s any) string   { return Colorize(Purple+GrayBackground, s) }
+func InPurpleOverWhite(s any) string  { return Colorize(Purple+WhiteBackground, s) }
+func InCyanOverBlack(s any) string    { return Colorize(Cyan+BlackBackground, s) }
+func InCyanOverRed(s any) string      { return Colorize(Cyan+RedBackground, s) }
+func InCyanOverGreen(s any) string    { return Colorize(Cyan+GreenBackground, s) }
+func InCyanOverYellow(s any) string   { return Colorize(Cyan+YellowBackground, s) }
+func InCyanOverBlue(s any) string     { return Colorize(Cyan+BlueBackground, s) }
+func InCyanOverPurple(s any) string   { return Colorize(Cyan+PurpleBackground, s) }
+func InCyanOverCyan(s any) string     { return Colorize(Cyan+CyanBackground, s) }
+func InCyanOverGray(s any) string     { return Colorize(Cyan+GrayBackground, s) }
+func InCyanOverWhite(s any) string    { return Colorize(Cyan+WhiteBackground, s) }
+func InGrayOverBlack(s any) string    { return Colorize(Gray+BlackBackground, s) }
+func InGrayOverRed(s any) string      { return Colorize(Gray+RedBackground, s) }
+func InGrayOverGreen(s any) string    { return Colorize(Gray+GreenBackground, s) }
+func InGrayOverYellow(s any) string   { return Colorize(Gray+YellowBackground, s) }
+func InGrayOverBlue(s any) string     { return Colorize(Gray+BlueBackground, s) }
+func InGrayOverPurple(s any) string   { return Colorize(Gray+PurpleBackground, s) }
+func InGrayOverCyan(s any) string     { return Colorize(Gray+CyanBackground, s) }
+func InGrayOverGray(s any) string     { return Colorize(Gray+GrayBackground, s) }
+func InGrayOverWhite(s any) string    { return Colorize(Gray+WhiteBackground, s) }
+func InWhiteOverBlack(s any) string   { return Colorize(White+BlackBackground, s) }
+func InWhiteOverRed(s any) string     { return Colorize(White+RedBackground, s) }
+func InWhiteOverGreen(s any) string   { return Colorize(White+GreenBackground, s) }
+func InWhiteOverYellow(s any) string  { return Colorize(White+YellowBackground, s) }
+func InWhiteOverBlue(s any) string    { return Colorize(White+BlueBackground, s) }
+func InWhiteOverPurple(s any) string  { return Colorize(White+PurpleBackground, s) }
+func InWhiteOverCyan(s any) string    { return Colorize(White+CyanBackground, s) }
+func InWhiteOverGray(s any) string    { return Colorize(White+GrayBackground, s) }
+func InWhiteOverWhite(s any) string   { return Colorize(White+WhiteBackground, s) }

--- a/color_test.go
+++ b/color_test.go
@@ -68,7 +68,7 @@ func TestColorize(t *testing.T) {
 
 func TestIn(t *testing.T) {
 	scenarios := []struct {
-		Func           func(string) string
+		Func           func(any) string
 		Name           string
 		ExpectedOutput string
 	}{


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
With this, it will now be possible to skip type conversion when passing a parameter to go-color.

Before:
```go
// Because functions took a string as parameter, you 
// first had to convert the parameter to a string.
println(color.InRed(strconv.Itoa(123)))
```
After:
```go
println(color.InRed(123))
```


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Added the documentation in `README.md`, if applicable.
