### PR TITLE
feat: Add automatic formatting and coloring function "Autof"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ color.InGreenOverBlue("This is green text on a blue background")
 ```
 Note that the example above is not exhaustive.
 
+#### Automatic coloring
+> ⚠ **WARNING**: This is an experimental feature and may be removed depending on user feedback.
+
+You may use `color.Autof(string, args...)` as a replacement to `fmt.Sprintf(string, args...)` but with colors for
+each argument:
+```go
+// 20 will be in red while "cookie jar" will be in green.
+println(color.Autof("I have $%.02f in my %s", 20, "cookie jar"))
+```
+
 
 ### Using Variables
 > ⚠ **WARNING**: By using this approach, you will not be able to disable colors with `color.Toggle(false)`. 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Note that the example above is not exhaustive.
 
 #### Automatic coloring
 > ⚠ **WARNING**: This is an experimental feature and may be removed depending on user feedback.
+> If you have any feedback, please comment on [poll: Keep or Remove color.Autof?](https://github.com/TwiN/go-color/discussions/13).
 
 You may use `color.Autof(string, args...)` as a replacement to `fmt.Sprintf(string, args...)` but with colors for
 each argument:

--- a/auto.go
+++ b/auto.go
@@ -1,0 +1,66 @@
+package color
+
+import (
+	"fmt"
+	"strings"
+)
+
+var colorsToRotate = []string{
+	Red, Green, Yellow, Blue,
+}
+
+// Autof automatically colors the arguments given for a specific format.
+// Works exactly like fmt.Sprintf
+//
+// Example:
+//
+//	println(Autof("Hello, %s.", "world"))
+func Autof(format string, a ...any) string {
+	if len(a) == 0 { // || Reset == ""
+		return fmt.Sprintf(format, a...)
+	}
+	currentColorIndex, maxColorIndex := 0, len(colorsToRotate)-1
+	//var coloredFormat string
+	var insideSpecifier bool
+	formatLength := len(format)
+	var lastMergedIndex int
+	sb := &strings.Builder{}
+	for i, c := range format {
+		if format[i] == '%' {
+			// If the character has a % before or after it, it's just an escaped %, so ignore it
+			if (i+1 < formatLength && format[i+1] == '%') || (i-1 >= 0 && format[i-1] == '%') {
+				// %% is an escape sequence for a single %, so we won't color this one
+				continue
+			}
+			// otherwise we're inside a specifier
+			insideSpecifier = true
+			// and we need to start coloring it
+			sb.WriteString(format[lastMergedIndex:i])
+			sb.WriteString(colorsToRotate[currentColorIndex])
+			sb.WriteRune(c)
+			lastMergedIndex = i + 1
+			currentColorIndex++
+			if currentColorIndex > maxColorIndex {
+				currentColorIndex = 0
+			}
+			// since we know we're inside a specifier, we can skip the next character now
+			continue
+		}
+		if insideSpecifier {
+			switch c {
+			case 'v', 's', 'd', 'f', 'F', 'g', 'G', 'e', 'E', 'x', 'X', 'p', 'b', 'T', 'o', 'O', 'c', 'q', 'U', 'w':
+				insideSpecifier = false
+				// this is the end of the specifier, so we'll add the last character of the specifier and stop coloring
+				sb.WriteString(format[lastMergedIndex : i+1])
+				sb.WriteString(Reset)
+				lastMergedIndex = i + 1
+			default:
+			}
+		}
+		continue
+	}
+	if lastMergedIndex < formatLength {
+		sb.WriteString(format[lastMergedIndex:])
+	}
+	return fmt.Sprintf(sb.String(), a...)
+}

--- a/auto.go
+++ b/auto.go
@@ -10,7 +10,10 @@ var colorsToRotate = []string{
 }
 
 // Autof automatically colors the arguments given for a specific format.
-// Works exactly like fmt.Sprintf
+// Works exactly like fmt.Sprintf.
+//
+// WARNING: THIS IS AN EXPERIMENTAL FEATURE AND IT MAY BE REMOVED BASED ON USER FEEDBACK.
+// IF YOU USE THIS FEATURE, PLEASE PROVIDE FEEDBACK ON https://github.com/TwiN/go-color/discussions/13
 //
 // Example:
 //

--- a/auto_bench_test.go
+++ b/auto_bench_test.go
@@ -1,0 +1,20 @@
+package color
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkAutof(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Autof("hello, %s. HRU %s? I'm %02d%% cute.", "world", "today", 50)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkSprintf(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		fmt.Sprintf("hello, %s. HRU %s? I'm %02d%% cute.", "world", "today", 50)
+	}
+	b.ReportAllocs()
+}

--- a/auto_test.go
+++ b/auto_test.go
@@ -1,0 +1,41 @@
+package color
+
+import "testing"
+
+func TestAutof(t *testing.T) {
+	scenarios := []struct {
+		InputFormat    string
+		InputArguments []any
+		ExpectedOutput string
+	}{
+		{
+			InputFormat:    "no args, no colors.",
+			InputArguments: nil,
+			ExpectedOutput: "no args, no colors.",
+		},
+		{
+			InputFormat:    "hello, %s.",
+			InputArguments: []any{"world"},
+			ExpectedOutput: "hello, " + Red + "world" + Reset + ".",
+		},
+		{
+			InputFormat:    "%s got %d%% in math.",
+			InputArguments: []any{"John Doe", 87},
+			ExpectedOutput: InRed("John Doe") + " got " + InGreen(87) + "% in math.",
+		},
+		{
+			InputFormat:    "%s sent %s$%.02f to %s",
+			InputArguments: []any{"John", "USD", 123.4, "Jane"},
+			ExpectedOutput: InRed("John") + " sent " + InGreen("USD") + "$" + InYellow("123.40") + " to " + InBlue("Jane"),
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.InputFormat, func(t *testing.T) {
+			output := Autof(scenario.InputFormat, scenario.InputArguments...)
+			if output != scenario.ExpectedOutput {
+				t.Errorf("expected %s, got %s", scenario.ExpectedOutput, output)
+			}
+			println(output)
+		})
+	}
+}

--- a/color_bench_test.go
+++ b/color_bench_test.go
@@ -1,0 +1,10 @@
+package color
+
+import "testing"
+
+func BenchmarkInBlackOverGreen(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		InBlackOverGreen("hello, world")
+	}
+	b.ReportAllocs()
+}


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Replacement for `fmt.Sprintf`, but each argument is colored:
```go
color.Autof("%s sent %s$%.02f to %s", "John", "USD", 123.4, "Jane")
```
![image](https://user-images.githubusercontent.com/15699766/202966213-37aa056d-2fdb-48c1-bac8-d7d6d4143d38.png)


This is an experimental feature and may be removed depending on user feedback.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
